### PR TITLE
'Run all' from cold colab nb open not possible -- my edits forcing functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 A repo where I explain how to do data story telling
 
 
-* [Data_Story_Telling_Notebook](https://github.com/noahgift/data-story-telling/blob/main/Data_Story_Telling.ipynb)
+[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://github.com/noahgift/data-story-telling/blob/main/Data_Story_Telling.ipynb)
 
 
 ![Screen Shot 2021-03-13 at 10 17 13 AM](https://user-images.githubusercontent.com/58792/111034819-5747ba00-83e5-11eb-8c5f-94b080cad634.png)

--- a/pullrequest.txt
+++ b/pullrequest.txt
@@ -1,6 +1,0 @@
-ran thru the data story and edited code to force functionality
-
-minor syntax errors, e.g., cufflinks not imported prior to use; column typos for ball players section
-
-issue: udpated column headers; zillow's econ data api is recommended, as the column headers have changed since Q1 2021
-idea: in the future demo accessing the published data via the Econ Data API

--- a/pullrequest.txt
+++ b/pullrequest.txt
@@ -1,0 +1,6 @@
+ran thru the data story and edited code to force functionality
+
+minor syntax errors, e.g., cufflinks not imported prior to use; column typos for ball players section
+
+issue: udpated column headers; zillow's econ data api is recommended, as the column headers have changed since Q1 2021
+idea: in the future demo accessing the published data via the Econ Data API


### PR DESCRIPTION
Hi! I wanted to help the mission of your repo and enable a 'run all' for the notebook.  Thus I updated:

- column names in the MLB ingestion section
- the url for ingestion in the Matthew Effect section
- column names and cascading data functions in the Matthew Effect ingestion and EDA sections


Note on the Matthew Effect section: It's unclear how long the Zillow zhvi url I've updated will remain functional, as calls to Zillow's EconData API are standard practice.


Please advise if there is a protocol step I've missed in merging the .ipynb file, and apologies in advance for any inconvenience therein.